### PR TITLE
feat: add playback rate and frame stepping controls

### DIFF
--- a/index.html
+++ b/index.html
@@ -33,7 +33,20 @@
       </div>
       <div class="row mt8">
         <button id="playPause">Lecture / Pause</button>
-        <span class="hint">Astuce : réglez le timing d'un arrêt en mettant la vidéo en pause exactement au bon moment.</span>
+        <button id="frameBack">&larr;1 frame</button>
+        <button id="frameForward">1 frame&rarr;</button>
+        <label for="playbackRate">Vitesse :</label>
+        <select id="playbackRate">
+          <option value="0.25">0.25×</option>
+          <option value="0.5">0.5×</option>
+          <option value="0.75">0.75×</option>
+          <option value="1" selected>1×</option>
+          <option value="1.25">1.25×</option>
+          <option value="1.5">1.5×</option>
+          <option value="1.75">1.75×</option>
+          <option value="2">2×</option>
+        </select>
+        <span class="hint">Astuce : réglez le timing d'un arrêt en mettant la vidéo en pause exactement au bon moment. Utilisez la vitesse et les boutons « ←1 frame » / « 1 frame→ » pour un contrôle précis.</span>
       </div>
     </section>
 


### PR DESCRIPTION
## Summary
- add playback speed selector and frame step buttons to video controls
- hook up playback rate and frame-step events in app.js
- estimate video framerate to support frame stepping

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a57b8e480483218f65975a935e5626