### PR TITLE
Add reaction time analytics and JSON export

### DIFF
--- a/index.html
+++ b/index.html
@@ -87,8 +87,16 @@
         <input type="file" id="scenarioFile" accept="application/json"/>
         <button id="startSession">Démarrer la séance</button>
         <button id="exportCSV">Exporter résultats (CSV)</button>
+        <button id="exportJSON">Exporter résultats (JSON)</button>
       </div>
       <div id="sessionStats"></div>
+    </section>
+
+    <section class="panel">
+      <h2>Graphiques</h2>
+      <canvas id="rtHistogram" width="400" height="200"></canvas>
+      <h3>Scores par arrêt</h3>
+      <ul id="perStopScores"></ul>
     </section>
   </main>
 


### PR DESCRIPTION
## Summary
- calculate reaction time distributions and per-stop accuracy
- render histogram and per-stop scores with canvas
- allow exporting session results as JSON

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a6dfbfffec8321851fb1960344d901