### PR TITLE
feat: persist and manage scenarios

### DIFF
--- a/index.html
+++ b/index.html
@@ -82,6 +82,21 @@
     </section>
 
     <section class="panel">
+      <h2>Mes scénarios</h2>
+      <div class="row">
+        <label>Titre :
+          <input type="text" id="scenarioTitle" placeholder="Nom du scénario"/>
+        </label>
+      </div>
+      <div class="row mt8">
+        <button id="saveScenarioBtn">Enregistrer</button>
+        <select id="scenarioList"></select>
+        <button id="loadScenarioBtn">Charger</button>
+        <button id="deleteScenarioBtn">Supprimer</button>
+      </div>
+    </section>
+
+    <section class="panel">
       <h2>3) Mode Lecture / Entraînement</h2>
       <div class="row">
         <input type="file" id="scenarioFile" accept="application/json"/>


### PR DESCRIPTION
## Summary
- add "Mes scénarios" section with save/load/delete controls
- implement localStorage-based scenarioStore with save, load and delete helpers
- allow renaming scenario titles and refresh list of stored scenarios

## Testing
- `npm test` *(fails: package.json missing)*
- `node --check app.js && echo "Syntax OK"`


------
https://chatgpt.com/codex/tasks/task_e_68a9dd98a158832198a2d060066fb051