### PR TITLE
Add session history with export/import

### DIFF
--- a/index.html
+++ b/index.html
@@ -98,6 +98,16 @@
       <h3>Scores par arrêt</h3>
       <ul id="perStopScores"></ul>
     </section>
+
+    <section class="panel">
+      <h2>Historique</h2>
+      <ul id="historyList"></ul>
+      <div id="historyStats"></div>
+      <div class="row">
+        <button id="exportHistory">Exporter historique (JSON)</button>
+        <input type="file" id="importHistory" accept="application/json"/>
+      </div>
+    </section>
   </main>
 
   <footer>


### PR DESCRIPTION
## Summary
- track session history in localStorage including date, scenario title, stats and results
- save history automatically after each session and display summary stats
- add Historique panel with listing and export/import controls

## Testing
- `node --check app.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a9dffb06508321843e93be6c28a477