### PR TITLE
fix: stabilize stats chart rendering

### DIFF
--- a/app.js
+++ b/app.js
@@ -790,7 +790,7 @@ closeSummaryBtn?.addEventListener("click", () => {
 
 // Événements globaux
 window.addEventListener("resize", () => { resizeOverlayToVideo(); });
-document.addEventListener("DOMContentLoaded", () => { ensureWrap(); resizeOverlayToVideo(); });
+document.addEventListener("DOMContentLoaded", () => { ensureWrap(); resizeOverlayToVideo(); renderSessionStats(); });
 videoEl?.addEventListener("loadedmetadata", resizeOverlayToVideo);
 videoEl?.addEventListener("loadedmetadata", () => {
   try {
@@ -818,4 +818,3 @@ videoEl?.addEventListener("loadedmetadata", () => {
   }
 });
 videoEl?.addEventListener("play", () => { if (sessionActive && pauseGuard) requestAnimationFrame(tickStopWatcher); });
-setInterval(renderSessionStats, 500);


### PR DESCRIPTION
## Summary
- avoid continuous stats refresh by removing interval loop
- compute and render stats once on load and when sessions complete

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a9e3e14e388321b4aaf1b6c70bccb5