### PR TITLE
Add guarded options container for session choices

### DIFF
--- a/app.js
+++ b/app.js
@@ -122,6 +122,7 @@ function hidePrompt() { if(!overlayPrompt) return; overlayPrompt.classList.add("
 function clearOptions() { if(!optionsWrap) return; optionsWrap.innerHTML = ""; optionsWrap.classList.add("hidden"); }
 function renderOptions(options, onPick) {
   clearOptions();
+  if (!optionsWrap) return;
   options.forEach(opt => { const b = document.createElement("button"); b.textContent = opt; b.onclick = () => onPick(opt); optionsWrap.appendChild(b); });
   optionsWrap.classList.remove("hidden"); positionOptionsWrap();
 }

--- a/index.html
+++ b/index.html
@@ -20,6 +20,7 @@
         <video id="player" playsinline></video>
         <canvas id="overlay"></canvas>
         <div id="overlayPrompt" class="hidden"></div>
+        <div id="optionsWrap" class="hidden"></div>
         <div id="sessionEnd" class="hidden">
           <div class="summary">
             <h3>Fin de l'exercice</h3>

--- a/styles.css
+++ b/styles.css
@@ -15,6 +15,7 @@ button:disabled { background: #3b4150; cursor: not-allowed; }
 .video-wrap { position: relative; width: 100%; }
 #overlay { position: absolute; top: 0; left: 0; pointer-events: none; }
 #overlayPrompt { position: absolute; background: rgba(0,0,0,0.8); color: white; padding: 10px 12px; border-radius: 8px; transform: translate(-50%, -100%); pointer-events: none; font-size: 14px; max-width: 70%; text-align: center; }
+#optionsWrap { display: flex; gap: 8px; }
 .hidden { display: none !important; }
 table { width: 100%; border-collapse: collapse; margin-top: 8px; }
 th, td { border-bottom: 1px solid #272b33; padding: 8px; text-align: left; font-size: 14px; }


### PR DESCRIPTION
## Summary
- insert `optionsWrap` in video section for rendering decision buttons
- style `#optionsWrap` for visible option layout
- guard `renderOptions` against missing container

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ab14c784808321b498ddbf89c3368d