### PR TITLE
feat: add qa box styling

### DIFF
--- a/app.js
+++ b/app.js
@@ -100,10 +100,6 @@ function positionPrompt() {
   overlayPrompt.style.top  = (rect.top  + 12) + "px";
   overlayPrompt.style.transform = "none";
   overlayPrompt.style.maxWidth = Math.max(260, rect.width * 0.5) + "px";
-  overlayPrompt.style.background = "rgba(0,0,0,0.55)";
-  overlayPrompt.style.color = "#fff";
-  overlayPrompt.style.padding = "8px 10px";
-  overlayPrompt.style.borderRadius = "8px";
   overlayPrompt.style.fontWeight = "600";
   overlayPrompt.style.zIndex = 9999;
 }

--- a/index.html
+++ b/index.html
@@ -19,8 +19,8 @@
       <div class="video-wrap">
         <video id="player" playsinline></video>
         <canvas id="overlay"></canvas>
-        <div id="overlayPrompt" class="hidden"></div>
-        <div id="optionsWrap" class="hidden"></div>
+        <div id="overlayPrompt" class="qa-box hidden"></div>
+        <div id="optionsWrap" class="qa-box hidden"></div>
         <div id="sessionEnd" class="hidden">
           <div class="summary">
             <h3>Fin de l'exercice</h3>

--- a/styles.css
+++ b/styles.css
@@ -14,8 +14,9 @@ button:disabled { background: #3b4150; cursor: not-allowed; }
 #player { display: block; width: 100%; max-height: 60vh; background: black; border-radius: 12px; }
 .video-wrap { position: relative; width: 100%; }
 #overlay { position: absolute; top: 0; left: 0; pointer-events: none; }
-#overlayPrompt { position: absolute; background: rgba(0,0,0,0.8); color: white; padding: 10px 12px; border-radius: 8px; transform: translate(-50%, -100%); pointer-events: none; font-size: 14px; max-width: 70%; text-align: center; }
+#overlayPrompt { position: absolute; color: white; transform: translate(-50%, -100%); pointer-events: none; font-size: 14px; max-width: 70%; text-align: center; }
 #optionsWrap { display: flex; gap: 8px; }
+.qa-box { background: rgba(0,0,0,0.5); padding: 8px 10px; border-radius: 8px; }
 .hidden { display: none !important; }
 table { width: 100%; border-collapse: collapse; margin-top: 8px; }
 th, td { border-bottom: 1px solid #272b33; padding: 8px; text-align: left; font-size: 14px; }


### PR DESCRIPTION
## Summary
- add shared `.qa-box` style for overlay prompt and options
- apply `.qa-box` to HTML prompts and remove inline background handling

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ab1bef3dd883218af7a3f5ba07bde7