### PR TITLE
Anchor prompts relative to player area

### DIFF
--- a/app.js
+++ b/app.js
@@ -94,23 +94,35 @@ function resizeOverlayToVideo() {
 // Place la consigne en HAUT-GAUCHE de la vidéo
 function positionPrompt() {
   if (!overlayPrompt) return;
+  ensureWrap();
   const rect = wrap.getBoundingClientRect();
-  overlayPrompt.style.position = "fixed";
-  overlayPrompt.style.left = (rect.left + 12) + "px";
-  overlayPrompt.style.top  = (rect.top  + 12) + "px";
-  overlayPrompt.style.transform = "none";
-  overlayPrompt.style.maxWidth = Math.max(260, rect.width * 0.5) + "px";
-  overlayPrompt.style.fontWeight = "600";
-  overlayPrompt.style.zIndex = 9999;
+  const box = overlayPrompt;
+  box.style.position = "absolute";
+  box.style.transform = "none";
+  box.style.maxWidth = Math.max(260, rect.width * 0.5) + "px";
+  box.style.fontWeight = "600";
+  box.style.zIndex = 9999;
+  let left = 12;
+  let top = 12;
+  left = Math.max(0, Math.min(rect.width - box.offsetWidth, left));
+  top = Math.max(0, Math.min(rect.height - box.offsetHeight, top));
+  box.style.left = left + "px";
+  box.style.top = top + "px";
 }
 
 function positionOptionsWrap() {
   if (!optionsWrap) return;
+  ensureWrap();
   const rect = wrap.getBoundingClientRect();
-  optionsWrap.style.position = "fixed";
-  optionsWrap.style.transform = "translate(-50%, -50%)";
-  optionsWrap.style.left = (rect.left + rect.width/2) + "px";
-  optionsWrap.style.top  = (rect.top  + rect.height*0.78) + "px";
+  const box = optionsWrap;
+  box.style.position = "absolute";
+  box.style.transform = "none";
+  let left = rect.width / 2 - box.offsetWidth / 2;
+  let top = rect.height * 0.78 - box.offsetHeight / 2;
+  left = Math.max(0, Math.min(rect.width - box.offsetWidth, left));
+  top = Math.max(0, Math.min(rect.height - box.offsetHeight, top));
+  box.style.left = left + "px";
+  box.style.top = top + "px";
 }
 
 function showPrompt(html) { if(!overlayPrompt) return; overlayPrompt.innerHTML = html; overlayPrompt.classList.remove("hidden"); positionPrompt(); }

--- a/styles.css
+++ b/styles.css
@@ -14,7 +14,8 @@ button:disabled { background: #3b4150; cursor: not-allowed; }
 #player { display: block; width: 100%; max-height: 60vh; background: black; border-radius: 12px; }
 .video-wrap { position: relative; width: 100%; }
 #overlay { position: absolute; top: 0; left: 0; pointer-events: none; }
-#overlayPrompt { position: absolute; color: white; transform: translate(-50%, -100%); pointer-events: none; font-size: 14px; max-width: 70%; text-align: center; }
+#overlayPrompt, #optionsWrap { position: absolute; }
+#overlayPrompt { color: white; pointer-events: none; font-size: 14px; max-width: 70%; text-align: center; }
 #optionsWrap { display: flex; gap: 8px; }
 .qa-box { background: rgba(0,0,0,0.5); padding: 8px 10px; border-radius: 8px; }
 .hidden { display: none !important; }


### PR DESCRIPTION
## Summary
- Position overlay prompt and options wrap absolutely within `#playerWrap`
- Constrain prompt and options to remain inside player bounds
- Make prompt and options wrappers absolute in CSS

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ab1df887888321955aa4dc7df2aa93