### PR TITLE
Use fade animations for prompts and options

### DIFF
--- a/app.js
+++ b/app.js
@@ -125,14 +125,53 @@ function positionOptionsWrap() {
   box.style.top = top + "px";
 }
 
-function showPrompt(html) { if(!overlayPrompt) return; overlayPrompt.innerHTML = html; overlayPrompt.classList.remove("hidden"); positionPrompt(); }
-function hidePrompt() { if(!overlayPrompt) return; overlayPrompt.classList.add("hidden"); }
-function clearOptions() { if(!optionsWrap) return; optionsWrap.innerHTML = ""; optionsWrap.classList.add("hidden"); }
-function renderOptions(options, onPick) {
-  clearOptions();
+function showPrompt(html) {
+  if (!overlayPrompt) return;
+  if (overlayPrompt._hideTO) {
+    clearTimeout(overlayPrompt._hideTO);
+    overlayPrompt._hideTO = null;
+  }
+  overlayPrompt.innerHTML = html;
+  overlayPrompt.classList.add("visible");
+  overlayPrompt.classList.remove("fade");
+  positionPrompt();
+}
+function hidePrompt() {
+  if (!overlayPrompt) return;
+  overlayPrompt.classList.remove("visible");
+  overlayPrompt.classList.add("fade");
+  if (overlayPrompt._hideTO) clearTimeout(overlayPrompt._hideTO);
+  overlayPrompt._hideTO = setTimeout(() => {
+    overlayPrompt.innerHTML = "";
+    overlayPrompt._hideTO = null;
+  }, 300);
+}
+function clearOptions() {
   if (!optionsWrap) return;
-  options.forEach(opt => { const b = document.createElement("button"); b.textContent = opt; b.onclick = () => onPick(opt); optionsWrap.appendChild(b); });
-  optionsWrap.classList.remove("hidden"); positionOptionsWrap();
+  optionsWrap.classList.remove("visible");
+  optionsWrap.classList.add("fade");
+  if (optionsWrap._hideTO) clearTimeout(optionsWrap._hideTO);
+  optionsWrap._hideTO = setTimeout(() => {
+    optionsWrap.innerHTML = "";
+    optionsWrap._hideTO = null;
+  }, 300);
+}
+function renderOptions(options, onPick) {
+  if (!optionsWrap) return;
+  if (optionsWrap._hideTO) {
+    clearTimeout(optionsWrap._hideTO);
+    optionsWrap._hideTO = null;
+  }
+  optionsWrap.innerHTML = "";
+  options.forEach(opt => {
+    const b = document.createElement("button");
+    b.textContent = opt;
+    b.onclick = () => onPick(opt);
+    optionsWrap.appendChild(b);
+  });
+  optionsWrap.classList.add("visible");
+  optionsWrap.classList.remove("fade");
+  positionOptionsWrap();
 }
 
 // Zones

--- a/index.html
+++ b/index.html
@@ -19,8 +19,8 @@
       <div class="video-wrap">
         <video id="player" playsinline></video>
         <canvas id="overlay"></canvas>
-        <div id="overlayPrompt" class="qa-box hidden"></div>
-        <div id="optionsWrap" class="qa-box hidden"></div>
+        <div id="overlayPrompt" class="qa-box fade"></div>
+        <div id="optionsWrap" class="qa-box fade"></div>
         <div id="sessionEnd" class="hidden">
           <div class="summary">
             <h3>Fin de l'exercice</h3>

--- a/styles.css
+++ b/styles.css
@@ -18,6 +18,8 @@ button:disabled { background: #3b4150; cursor: not-allowed; }
 #overlayPrompt { color: white; pointer-events: none; font-size: 14px; max-width: 70%; text-align: center; }
 #optionsWrap { display: flex; gap: 8px; }
 .qa-box { background: rgba(0,0,0,0.5); padding: 8px 10px; border-radius: 8px; }
+.fade { opacity: 0; transition: opacity 0.3s; pointer-events: none; }
+.visible { opacity: 1; pointer-events: auto; }
 .hidden { display: none !important; }
 table { width: 100%; border-collapse: collapse; margin-top: 8px; }
 th, td { border-bottom: 1px solid #272b33; padding: 8px; text-align: left; font-size: 14px; }


### PR DESCRIPTION
## Summary
- add `.fade` and `.visible` classes for smooth opacity transitions
- toggle prompt and option visibility with fade transitions and timed cleanup
- initialize prompt and option containers with fade class

## Testing
- `node -c app.js`
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ab1fae2e208321b39a669bc8782b34