### PR TITLE
Center overlay prompt and update position

### DIFF
--- a/app.js
+++ b/app.js
@@ -120,7 +120,7 @@ function positionPrompt() {
   box.style.maxWidth = Math.max(260, rect.width * 0.5) + "px";
   box.style.fontWeight = "600";
   box.style.zIndex = 9999;
-  let left = 12;
+  let left = rect.width / 2 - box.offsetWidth / 2;
   let top = 12;
   left = Math.max(0, Math.min(rect.width - box.offsetWidth, left));
   top = Math.max(0, Math.min(rect.height - box.offsetHeight, top));

--- a/styles.css
+++ b/styles.css
@@ -15,7 +15,7 @@ button:disabled { background: #3b4150; cursor: not-allowed; }
 .video-wrap { position: relative; width: 100%; }
 #overlay { position: absolute; top: 0; left: 0; pointer-events: none; }
 #overlayPrompt, #optionsWrap { position: absolute; }
-#overlayPrompt { color: white; pointer-events: none; font-size: 14px; max-width: 70%; text-align: center; }
+#overlayPrompt { background: #2a6ef1; color: #FFFFFF; font-size: 120%; font-weight: bold; text-shadow: 0 0 3px #000; padding: 10px 14px; border-radius: 8px; pointer-events: none; max-width: 70%; text-align: center; }
 #optionsWrap { display: flex; gap: 8px; }
 .qa-box { background: rgba(0,0,0,0.5); padding: 8px 10px; border-radius: 8px; }
 .fade { opacity: 0; transition: opacity 0.3s; pointer-events: none; }


### PR DESCRIPTION
## Summary
- Style overlay prompt to use solid blue background, bold white text, and rounded corners.
- Center the on-screen prompt horizontally with a fixed top offset for consistent positioning.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ab304029fc8321bccbef5d9f77cff9