### PR TITLE
doc: clarify prompt positioning

### DIFF
--- a/app.js
+++ b/app.js
@@ -109,7 +109,11 @@ function resizeOverlayToVideo() {
   redrawOverlay();
 }
 
-// Place la consigne en HAUT-GAUCHE de la vidéo
+// Positionne la consigne au-dessus de la vidéo : centrée horizontalement
+// avec un décalage vertical fixe (12px). Les coordonnées sont ensuite
+// bornées pour rester dans les limites du conteneur.
+// Pour ajuster la position si l'interface évolue, modifier le calcul de
+// `left` et `top` ci-dessous en fonction des nouveaux repères ou marges.
 function positionPrompt() {
   if (!overlayPrompt) return;
   ensureWrap();


### PR DESCRIPTION
## Summary
- document how the overlay prompt is horizontally centered with a fixed top offset
- add guidance for adjusting `positionPrompt` when the UI changes

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ab32097c8c8321ab9ed985033e7bf8