### PR TITLE
feat: add global keyboard shortcuts and editor help

### DIFF
--- a/app.js
+++ b/app.js
@@ -16,12 +16,19 @@ const frameForwardBtn = $("#frameForward");
 const playbackRateSelect = $("#playbackRate");
 const optionsWrap = $("#optionsWrap");
 
+const KEYMAP = {
+  playPause: " ",
+  predict: "p",
+  decisionNext: "d",
+  defineAnswer: "r",
+};
+
 const videoFileInput = $("#videoFile");
 const scenarioFileInput = $("#scenarioFile");
 
-const addPredictBtn = $("#addPredict");
-const addDecisionBtn = $("#addDecision");
-const markAnswerBtn = $("#markAnswer");
+const addPredictBtn = $("#btnAddPredictStop");
+const addDecisionBtn = $("#btnAddDecisionStop");
+const markAnswerBtn = $("#btnDefineAnswer");
 const exportScenarioBtn = $("#exportScenario");
 
 const decisionOptionsInput = $("#decisionOptions");
@@ -38,6 +45,57 @@ const rtHistogramCanvas = $("#rtHistogram");
 const perStopListEl = $("#perStopScores");
 const progressChartCanvas = $("#progressChart");
 const sessionComparisonCanvas = $("#sessionComparisonChart");
+
+function flashButton(btn) {
+  if (!btn) return;
+  btn.classList.add("flash");
+  setTimeout(() => btn.classList.remove("flash"), 200);
+  btn.focus?.();
+}
+
+function isTypingElement(el) {
+  if (!el) return false;
+  const tag = el.tagName?.toLowerCase();
+  return ["input", "textarea", "select"].includes(tag) || el.isContentEditable;
+}
+
+function globalKeyHandler(e) {
+  if (e.defaultPrevented || e.repeat) return;
+  if (isTypingElement(e.target)) return;
+  if (!sessionEnd?.classList.contains("hidden")) return;
+  const key = e.key.toLowerCase();
+  switch (key) {
+    case KEYMAP.playPause:
+      e.preventDefault();
+      if (!videoEl.src) break;
+      if (videoEl.paused) { videoEl.play(); } else { videoEl.pause(); }
+      flashButton(playPauseBtn);
+      break;
+    case KEYMAP.predict:
+      if (!editorMode) break;
+      e.preventDefault();
+      addPredictBtn?.click();
+      flashButton(addPredictBtn);
+      break;
+    case KEYMAP.decisionNext:
+      if (!editorMode) break;
+      e.preventDefault();
+      addDecisionBtn?.click();
+      flashButton(addDecisionBtn);
+      break;
+    case KEYMAP.defineAnswer:
+      if (!editorMode) break;
+      e.preventDefault();
+      markAnswerBtn?.click();
+      flashButton(markAnswerBtn);
+      break;
+  }
+}
+
+document.addEventListener("keydown", globalKeyHandler);
+window.addEventListener("beforeunload", () => {
+  document.removeEventListener("keydown", globalKeyHandler);
+});
 
 // Tolérance (en pixels) pour les clics précis
 const tolPx = 20;

--- a/index.html
+++ b/index.html
@@ -54,11 +54,12 @@
     <section class="panel">
       <h2>2) Mode Éditeur</h2>
       <div class="row">
-        <button id="addPredict">Ajouter arrêt « Prédire l'atterrissage »</button>
-        <button id="addDecision">Ajouter arrêt « Décision coup suivant »</button>
-        <button id="markAnswer">Définir la réponse (cliquer sur la vidéo)</button>
+        <button id="btnAddPredictStop">Ajouter arrêt « Prédire l'atterrissage » <span class="shortcut-badge">P</span></button>
+        <button id="btnAddDecisionStop">Ajouter arrêt « Décision coup suivant » <span class="shortcut-badge">D</span></button>
+        <button id="btnDefineAnswer">Définir la réponse (cliquer sur la vidéo) <span class="shortcut-badge">R</span></button>
         <button id="exportScenario">Exporter le scénario (JSON)</button>
       </div>
+      <div class="shortcut-help">Espace = Lecture/Pause · P = Prédire l’atterrissage · D = Décision coup suivant · R = Définir la réponse</div>
       <div class="row">
         <label class="inline">
           <input type="checkbox" id="zoneMode"/>

--- a/styles.css
+++ b/styles.css
@@ -26,6 +26,34 @@ footer { padding: 12px 24px; border-top: 1px solid #23262d; color: #a8adbb; }
 .hint { color: #a8adbb; font-size: 13px; }
 .mt8 { margin-top: 8px; }
 
+.shortcut-badge {
+  background: #2a6ef1;
+  color: #fff;
+  border-radius: 6px;
+  padding: 2px 6px;
+  font-size: 12px;
+  margin-left: 6px;
+}
+
+.shortcut-help {
+  background: #2a6ef1;
+  color: #fff;
+  border-radius: 8px;
+  padding: 4px 8px;
+  font-size: 13px;
+  display: inline-block;
+  margin-bottom: 8px;
+}
+
+@keyframes flash {
+  from { box-shadow: 0 0 0 3px rgba(42,110,241,0.7); }
+  to { box-shadow: none; }
+}
+
+.flash {
+  animation: flash 0.2s ease;
+}
+
 /* Session end overlay */
 #sessionEnd { position: absolute; inset: 0; background: rgba(0,0,0,0.7); display: flex; align-items: center; justify-content: center; }
 #sessionEnd .summary { background: #11141a; border: 1px solid #2b3240; border-radius: 12px; padding: 16px; width: min(520px, 92%); }


### PR DESCRIPTION
## Summary
- add configurable KEYMAP and global key handling for play/pause and editor actions
- display shortcut badges and help line below editor buttons
- style visual shortcut hints and feedback animation

## Testing
- `npm test` *(fails: package.json missing)*
- manual: Space toggles video playback without scrolling
- manual: P/D/R trigger correct editor actions only in editor mode
- manual: Typing in text fields ignores shortcuts
- manual: shortcut badges and help line render correctly

------
https://chatgpt.com/codex/tasks/task_e_68ab34c122a48321b5bd52d81ae4907b