### PR TITLE
Add exercise restart functionality

### DIFF
--- a/index.html
+++ b/index.html
@@ -36,6 +36,7 @@
         <button id="playPause">Lecture / Pause</button>
         <button id="frameBack">&larr;1 frame</button>
         <button id="frameForward">1 frame&rarr;</button>
+        <button id="btnRestartExercise">Recommencer</button>
         <label for="playbackRate">Vitesse :</label>
         <select id="playbackRate">
           <option value="0.25">0.25×</option>


### PR DESCRIPTION
## Summary
- Add "Recommencer" button alongside video controls to restart exercise
- Implement `resetExercise` to clear timers, state, and visual feedback
- Bind restart button to confirmation and reset logic

## Testing
- `node --check app.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ab39228a0083219453c5f7978fc763