### PR TITLE
Add restart exercise control

### DIFF
--- a/app.js
+++ b/app.js
@@ -242,6 +242,14 @@ function clearOptions() {
     optionsWrap._hideTO = null;
   }, 300);
 }
+
+function showRestartButton() {
+  restartExerciseBtn?.classList.remove("hidden");
+}
+
+function hideRestartButton() {
+  restartExerciseBtn?.classList.add("hidden");
+}
 function renderOptions(options, onPick) {
   if (!optionsWrap) return;
   if (optionsWrap._hideTO) {
@@ -366,10 +374,12 @@ function startSession() {
     videoEl.currentTime = 0;
     videoEl.play();
     tickStopWatcher();
+    showRestartButton();
   });
 }
 
 function finishSession() {
+  hideRestartButton();
   clearTimeout(endSessionTimeoutId);
   endSessionTimeoutId = null;
   sessionActive = false;
@@ -423,6 +433,7 @@ function resetTrainingState() {
   awaitingAnswer = false;
   sessionActive = false;
   editorMode = true;
+  hideRestartButton();
   clickFeedbacks = [];
   feedbackFlash = null;
   hidePrompt();
@@ -1056,6 +1067,7 @@ restartSessionBtn?.addEventListener("click", () => {
 closeSummaryBtn?.addEventListener("click", () => {
   sessionEnd?.classList.add("hidden");
   editorMode = true;
+  hideRestartButton();
 });
 
 // Événements globaux

--- a/index.html
+++ b/index.html
@@ -36,7 +36,7 @@
         <button id="playPause">Lecture / Pause</button>
         <button id="frameBack">&larr;1 frame</button>
         <button id="frameForward">1 frame&rarr;</button>
-        <button id="btnRestartExercise">Recommencer</button>
+        <button id="btnRestartExercise" class="hidden">Recommencer</button>
         <label for="playbackRate">Vitesse :</label>
         <select id="playbackRate">
           <option value="0.25">0.25×</option>


### PR DESCRIPTION
## Summary
- Hide restart button by default and expose helpers to toggle its visibility
- Show restart button on session start and hide it when training ends or editor mode resumes

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open 'package.json')*


------
https://chatgpt.com/codex/tasks/task_e_68ab4103b4fc8321b25a718e28fc0fe9