### PR TITLE
Scroll video into view on session start

### DIFF
--- a/app.js
+++ b/app.js
@@ -6,6 +6,7 @@ const videoEl = $("#player");
 videoEl.framerate = 25;
 const overlay = $("#overlay");
 const overlayPrompt = $("#overlayPrompt");
+const videoContainer = $("#videoContainer");
 const sessionEnd = $("#sessionEnd");
 const summaryStats = $("#summaryStats");
 const restartSessionBtn = $("#restartSession");
@@ -1024,6 +1025,10 @@ scenarioFileInput?.addEventListener("change", (e) => {
 
 startSessionBtn?.addEventListener("click", () => {
   if (!scenario.stops?.length) { alert("Pas d'arrêts. Chargez un scénario ou créez-en dans l'éditeur."); return; }
+  try {
+    videoContainer?.scrollIntoView({ behavior: "smooth", block: "center" });
+    videoEl.focus?.();
+  } catch (e) {}
   startSession();
 });
 

--- a/index.html
+++ b/index.html
@@ -16,7 +16,7 @@
     <section class="panel">
       <h2>1) Charger un <u>fichier vidéo</u> depuis votre ordinateur</h2>
       <input type="file" id="videoFile" accept="video/*"/>
-      <div class="video-wrap">
+      <div id="videoContainer" class="video-wrap">
         <video id="player" playsinline></video>
         <canvas id="overlay"></canvas>
         <div id="overlayPrompt" class="qa-box fade"></div>


### PR DESCRIPTION
## Summary
- Add `videoContainer` id to the video wrapper and cache it in `app.js`
- Scroll the video container into view and focus the player when starting a session
- Wrap scroll and focus in try/catch to avoid mobile browser errors

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ab41a5076c83218b36800bbf6a0df8