### PR TITLE
Streamline overlay sizing via CSS

### DIFF
--- a/app.js
+++ b/app.js
@@ -172,10 +172,6 @@ function ensureWrap() {
   videoEl.parentNode.insertBefore(wrap, videoEl);
   wrap.appendChild(videoEl);
   wrap.appendChild(overlay);
-  overlay.style.position = "absolute";
-  overlay.style.left = "0px";
-  overlay.style.top = "0px";
-  overlay.style.pointerEvents = "none";
 }
 
 // Helpers UI
@@ -184,7 +180,6 @@ function resizeOverlayToVideo() {
   const w = videoEl.clientWidth || videoEl.videoWidth || 640;
   const h = videoEl.clientHeight || (videoEl.videoWidth ? videoEl.videoHeight * (w / videoEl.videoWidth) : 360);
   overlay.width = w; overlay.height = h;
-  overlay.style.width = w + "px"; overlay.style.height = h + "px";
   positionPrompt(); positionOptionsWrap();
   redrawOverlay();
 }

--- a/styles.css
+++ b/styles.css
@@ -13,7 +13,13 @@ button:hover { filter: brightness(1.05); }
 button:disabled { background: #3b4150; cursor: not-allowed; }
 #player { display: block; width: 100%; max-height: 60vh; background: black; border-radius: 12px; }
 .video-wrap { position: relative; width: 100%; }
-#overlay { position: absolute; top: 0; left: 0; pointer-events: none; }
+#overlay {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  pointer-events: none;
+}
 #overlayPrompt, #optionsWrap { position: absolute; }
 #overlayPrompt { background: #2a6ef1; color: #FFFFFF; font-size: 120%; font-weight: bold; text-shadow: 0 0 3px #000; padding: 10px 14px; border-radius: 8px; pointer-events: none; max-width: 70%; text-align: center; }
 #optionsWrap { display: flex; gap: 8px; background: rgba(0,0,0,0.5); padding: 8px 10px; border-radius: 8px; }


### PR DESCRIPTION
## Summary
- Expand `#overlay` CSS to cover parent via `inset:0`, removing JS width/height styling
- Simplify `resizeOverlayToVideo()` so it only adjusts canvas resolution
- Remove redundant style assignments when wrapping video and overlay

## Testing
- `node --check app.js`
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_68ab46d172b083219d64800a3a1f1f29