### PR TITLE
refactor: reuse answer coords when drawing feedback

### DIFF
--- a/app.js
+++ b/app.js
@@ -548,8 +548,8 @@ function handleStop(index) {
         const chosenColor = correct ? "rgba(16,185,129,0.95)" : "rgba(239,68,68,0.95)";
         flashCircle(rel.cx, rel.cy, chosenColor, 1500);
         if (!correct) {
-          const dispX = stop.answerPoint.x / (videoEl.videoWidth || 1) * overlay.width;
-          const dispY = stop.answerPoint.y / (videoEl.videoHeight || 1) * overlay.height;
+          const dispX = answerSrcX / (videoEl.videoWidth || 1) * overlay.width;
+          const dispY = answerSrcY / (videoEl.videoHeight || 1) * overlay.height;
           flashCircle(dispX, dispY, "rgba(16,185,129,0.95)", 1500);
         }
       } else {


### PR DESCRIPTION
## Summary
- Ensure predict-landing stops handle stored answer points as pixel coordinates
- Reuse source coordinates when drawing corrective feedback circles

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ab4d593e90832189fd59d5e6ad6087