### PR TITLE
Avoid duplicate editor click handlers

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,10 @@
 # app
+
+## Editor listener lifecycle
+
+The editor binds temporary click handlers when defining an answer for a stop.
+Each step first removes any previous handler before attaching a new one and
+most handlers are registered with `{ once: true }`. This ensures that repeated
+invocations (or an aborted action) do not accumulate duplicate listeners.
+The helper `cleanupEditorClickHandlers()` in `app.js` can be called to cancel
+any in-progress editor interaction.


### PR DESCRIPTION
## Summary
- track editor click handlers and remove them before attaching new ones
- use `{ once: true }` for one-shot listeners and cleanup on reset
- document listener lifecycle in the README

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ab4e1179c883219e2f06d7278f7f73