### PR TITLE
fix click capture after centering

### DIFF
--- a/index.html
+++ b/index.html
@@ -19,7 +19,7 @@
       <div id="videoContainer" class="video-wrap">
         <video id="player" playsinline></video>
         <canvas id="overlay"></canvas>
-        <div id="clickOverlay"></div>
+        <div id="clickOverlay" tabindex="0"></div>
         <div id="overlayPrompt" class="qa-box fade"></div>
         <div id="optionsWrap" class="qa-box fade"></div>
         <div id="sessionEnd" class="hidden">


### PR DESCRIPTION
## Summary
- wait for scrolling to finish before re-enabling click capture
- focus click overlay and make it keyboard-focusable

## Testing
- `npm test` *(fails: package.json missing)*
- `node --check app.js`


------
https://chatgpt.com/codex/tasks/task_e_68ab5200c2848321a63d1eae6e383217