### PR TITLE
Add zone-config styling to editor options

### DIFF
--- a/index.html
+++ b/index.html
@@ -55,14 +55,14 @@
 
     <section class="panel">
       <h2>2) Mode Éditeur</h2>
-      <div class="row">
+        <div class="row">
         <button id="btnAddPredictStop">Ajouter arrêt « Prédire l'atterrissage » <span class="shortcut-badge">P</span></button>
         <button id="btnAddDecisionStop">Ajouter arrêt « Décision coup suivant » <span class="shortcut-badge">D</span></button>
         <button id="btnDefineAnswer">Définir la réponse (cliquer sur la vidéo) <span class="shortcut-badge">R</span></button>
         <button id="exportScenario">Exporter le scénario (JSON)</button>
       </div>
       <div class="shortcut-help">Espace = Lecture/Pause · P = Prédire l’atterrissage · D = Décision coup suivant · R = Définir la réponse</div>
-      <div class="row">
+        <div class="row zone-config">
         <label class="inline">
           <input type="checkbox" id="zoneMode"/>
           Mode zones (2×2) pour « Prédire »

--- a/styles.css
+++ b/styles.css
@@ -5,6 +5,13 @@ h1 { margin: 0 0 6px; font-size: 24px; }
 main { padding: 16px 24px; display: grid; gap: 20px; }
 .panel { background: #14171f; border: 1px solid #272b33; border-radius: 12px; padding: 16px; }
 .row { display: flex; flex-wrap: wrap; gap: 8px; align-items: center; margin: 8px 0; }
+.zone-config {
+   border: 2px solid #FFC107;
+   border-radius: 6px;
+   padding: 10px;
+   margin-top: 12px;
+   color: #fff;
+ }
 label { display: flex; gap: 8px; align-items: center; }
 label.inline { gap: 6px; }
 input[type=file], input[type=text] { background: #0e0f12; color: #e7e9ee; border: 1px solid #333844; border-radius: 8px; padding: 8px; }


### PR DESCRIPTION
## Summary
- highlight editor option row with new `zone-config` class
- style configuration zone with yellow border and padding

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ab55a36370832196900201b2350b18