### PR TITLE
Use inline-flex for decision config block

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -17,7 +17,7 @@ main { padding: 16px 24px; display: grid; gap: 20px; }
   border-radius: 6px;
   padding: 10px;
   margin-top: 12px;
-  display: flex;
+  display: inline-flex;
   flex-direction: column;
   gap: 8px;
 }


### PR DESCRIPTION
## Summary
- Use `inline-flex` for `.decision-config` to allow it to shrink to its content while keeping column layout and spacing.

## Testing
- `npm test` *(fails: ENOENT could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ab5f04e20c8321b277a9f4af46f2ad