### PR TITLE
Add prefix to shortcut help and simplify styling

### DIFF
--- a/index.html
+++ b/index.html
@@ -61,7 +61,7 @@
         <button id="btnDefineAnswer">Définir la réponse (cliquer sur la vidéo) <span class="shortcut-badge">R</span></button>
         <button id="exportScenario">Exporter le scénario (JSON)</button>
       </div>
-      <div class="shortcut-help">Espace = Lecture/Pause · P = Prédire l’atterrissage · D = Décision coup suivant · R = Définir la réponse</div>
+      <div class="shortcut-help">Raccourcis : Espace = Lecture/Pause · P = Prédire l’atterrissage · D = Décision coup suivant · R = Définir la réponse</div>
         <div class="row">
           <label class="zone-mode">
             <input type="checkbox" id="zoneMode"/>

--- a/styles.css
+++ b/styles.css
@@ -70,12 +70,11 @@ footer { padding: 12px 24px; border-top: 1px solid #23262d; color: #a8adbb; }
   margin-left: 6px;
 }
 
-.shortcut-help {
-  color: #fff;
-  font-weight: 500;
-  margin-top: 8px;
-  font-size: 13px;
-}
+  .shortcut-help {
+    color: #fff;
+    margin-top: 8px;
+    font-size: 13px;
+  }
 
 @keyframes flash {
   from { box-shadow: 0 0 0 3px rgba(42,110,241,0.7); }


### PR DESCRIPTION
## Summary
- Add "Raccourcis" prefix to shortcut help text for clarity
- Remove bold font weight from shortcut help style for normal white text

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ab60e340648321b33f5ed74387673b