### PR TITLE
Déplacer le bouton Décision dans la configuration

### DIFF
--- a/index.html
+++ b/index.html
@@ -57,7 +57,6 @@
       <h2>2) Mode Éditeur</h2>
         <div class="row">
         <button id="btnAddPredictStop">Ajouter arrêt « Prédire l'atterrissage » <span class="shortcut-badge">P</span></button>
-        <button id="btnAddDecisionStop">Ajouter arrêt « Décision coup suivant » <span class="shortcut-badge">D</span></button>
         <button id="btnDefineAnswer">Définir la réponse (cliquer sur la vidéo) <span class="shortcut-badge">R</span></button>
         <button id="exportScenario">Exporter le scénario (JSON)</button>
       </div>
@@ -69,6 +68,7 @@
           </label>
         </div>
         <div class="decision-config">
+          <button id="btnAddDecisionStop">Ajouter arrêt « Décision coup suivant » <span class="shortcut-badge">D</span></button>
           <label>Options (séparées par des virgules) pour « Décision » :
             <input type="text" id="decisionOptions" placeholder="ex : CD croisé, Revers long de ligne, Amorti, Lob"/>
           </label>


### PR DESCRIPTION
## Summary
- Déplace le bouton "Décision coup suivant" hors de la barre d'outils du mode éditeur pour le placer dans la configuration de décision
- Aligne l'ordre des éléments de configuration sur le bouton, puis les étiquettes "Options" et "Réponse correcte"

## Testing
- `npm test` *(échoué : package.json manquant)*

------
https://chatgpt.com/codex/tasks/task_e_68ab62b7d10883219fcd79499b5304a7