### PR TITLE
Remove decision button references from editor bar

### DIFF
--- a/index.html
+++ b/index.html
@@ -60,20 +60,11 @@
         <button id="btnDefineAnswer">Définir la réponse (cliquer sur la vidéo) <span class="shortcut-badge">R</span></button>
         <button id="exportScenario">Exporter le scénario (JSON)</button>
       </div>
-      <div class="shortcut-help">Raccourcis : Espace = Lecture/Pause · P = Prédire l’atterrissage · D = Décision coup suivant · R = Définir la réponse</div>
+      <div class="shortcut-help">Raccourcis : Espace = Lecture/Pause · P = Prédire l’atterrissage · R = Définir la réponse</div>
         <div class="row">
           <label class="zone-mode">
             <input type="checkbox" id="zoneMode"/>
             Mode zones (2×2) pour « Prédire »
-          </label>
-        </div>
-        <div class="decision-config">
-          <button id="btnAddDecisionStop">Ajouter arrêt « Décision coup suivant » <span class="shortcut-badge">D</span></button>
-          <label>Options (séparées par des virgules) pour « Décision » :
-            <input type="text" id="decisionOptions" placeholder="ex : CD croisé, Revers long de ligne, Amorti, Lob"/>
-          </label>
-          <label>Réponse correcte :
-            <input type="text" id="decisionCorrect" placeholder="Doit correspondre exactement à une option"/>
           </label>
         </div>
       <div>


### PR DESCRIPTION
## Summary
- Remove decision stop controls from editor section
- Update shortcut help to only include predict and answer actions

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ab6349ccd88321bf558c6456037c07