### PR TITLE
Déplace le bouton d'arrêt décision dans la configuration

### DIFF
--- a/index.html
+++ b/index.html
@@ -57,7 +57,6 @@
       <h2>2) Mode Éditeur</h2>
         <div class="row">
         <button id="btnAddPredictStop">Ajouter arrêt « Prédire l'atterrissage » <span class="shortcut-badge">P</span></button>
-        <button id="btnAddDecisionStop">Ajouter arrêt « Décision coup suivant » <span class="shortcut-badge">D</span></button>
         <button id="btnDefineAnswer">Définir la réponse (cliquer sur la vidéo) <span class="shortcut-badge">R</span></button>
         <button id="exportScenario">Exporter le scénario (JSON)</button>
       </div>
@@ -75,6 +74,7 @@
           <label>Réponse correcte :
             <input type="text" id="decisionCorrect" placeholder="Doit correspondre exactement à une option"/>
           </label>
+          <button id="btnAddDecisionStop">Ajouter arrêt « Décision coup suivant » <span class="shortcut-badge">D</span></button>
         </div>
       <div>
         <h3>Arrêts du scénario</h3>


### PR DESCRIPTION
## Summary
- Supprime le bouton "Décision coup suivant" de la rangée d'actions du mode éditeur
- Ajoute ce bouton après le champ "Réponse correcte" dans la configuration de décision

## Testing
- ⚠️ `npm test` (échec : fichier package.json introuvable)


------
https://chatgpt.com/codex/tasks/task_e_68ab67d7b35483219a43df77e3fad92a