### PR TITLE
Arrange editor controls with zone mode toggle

### DIFF
--- a/index.html
+++ b/index.html
@@ -55,18 +55,20 @@
 
     <section class="panel">
       <h2>2) Mode Éditeur</h2>
-        <div class="row">
-        <button id="btnAddPredictStop">Ajouter arrêt « Prédire l'atterrissage » <span class="shortcut-badge">P</span></button>
-        <button id="btnDefineAnswer">Définir la réponse (cliquer sur la vidéo) <span class="shortcut-badge">R</span></button>
+      <div class="row">
+        <label class="zone-mode">
+          <input type="checkbox" id="zoneMode"/>
+          Mode zones (2×2) pour « Prédire »
+        </label>
+      </div>
+      <div class="row between">
+        <div class="left-buttons">
+          <button id="btnAddPredictStop">Ajouter arrêt « Prédire l'atterrissage » <span class="shortcut-badge">P</span></button>
+          <button id="btnDefineAnswer">Définir la réponse (cliquer sur la vidéo) <span class="shortcut-badge">R</span></button>
+        </div>
         <button id="exportScenario">Exporter le scénario (JSON)</button>
       </div>
       <div class="shortcut-help">Raccourcis : Espace = Lecture/Pause · P = Prédire l’atterrissage · D = Décision coup suivant · R = Définir la réponse</div>
-        <div class="row">
-          <label class="zone-mode">
-            <input type="checkbox" id="zoneMode"/>
-            Mode zones (2×2) pour « Prédire »
-          </label>
-        </div>
         <div class="decision-config">
           <label>Options (séparées par des virgules) pour « Décision » :
             <input type="text" id="decisionOptions" placeholder="ex : CD croisé, Revers long de ligne, Amorti, Lob"/>

--- a/styles.css
+++ b/styles.css
@@ -7,6 +7,8 @@ h1 { margin: 0 0 6px; font-size: 24px; }
 main { padding: 16px 24px; display: grid; gap: 20px; }
 .panel { background: #14171f; border: 1px solid #272b33; border-radius: 12px; padding: 16px; }
 .row { display: flex; flex-wrap: wrap; gap: 8px; align-items: center; margin: 8px 0; }
+.row.between { justify-content: space-between; }
+.left-buttons { display: flex; gap: 8px; }
 /* Zone configuration removed; using zone-mode instead */
 
 .zone-mode {


### PR DESCRIPTION
## Summary
- Move "Mode zones (2×2) pour « Prédire »" toggle just under the editor title
- Group prediction and answer buttons on the left and separate JSON export on the right
- Add flex utilities for spacing and alignment

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ab6bfe5d188321819a13cc88bec3a1