### PR TITLE
feat: highlight decision answers before resuming video

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -32,6 +32,10 @@ input[type=file], input[type=text] { background: #0e0f12; color: #e7e9ee; border
 button { background: #2a6ef1; color: white; border: none; border-radius: 10px; padding: 10px 14px; cursor: pointer; }
 button:hover { filter: brightness(1.05); }
 button:disabled { background: #3b4150; cursor: not-allowed; }
+#optionsWrap button.correct,
+#optionsWrap button.correct:disabled { background: #16a34a; }
+#optionsWrap button.incorrect,
+#optionsWrap button.incorrect:disabled { background: #dc2626; }
 #player { display: block; width: 100%; max-height: 60vh; background: black; border-radius: 12px; }
 .video-wrap { position: relative; width: 100%; }
 #overlay {


### PR DESCRIPTION
## Summary
- show green/red feedback on decision answers before resuming video
- add styles for correct and incorrect decision options

## Testing
- `node --check app.js && echo "Syntax OK"`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ab6d3c0cf083219b077f174489ae29