### PR TITLE
Fix editor overlay blocking video controls

### DIFF
--- a/app.js
+++ b/app.js
@@ -1010,6 +1010,8 @@ function cleanupEditorClickHandlers() {
     clickOverlay.removeEventListener("click", zoneSelectHandler);
     zoneSelectHandler = null;
   }
+  // Ensure the overlay doesn't block interactions once handlers are removed.
+  clickOverlay.style.pointerEvents = "none";
 }
 
 function setAnswerForStop(index) {
@@ -1224,7 +1226,14 @@ closeSummaryBtn?.addEventListener("click", () => {
 });
 
 // Événements globaux
-document.addEventListener("DOMContentLoaded", () => { ensureWrap(); resizeOverlayToVideo(); renderSessionStats(); });
+document.addEventListener("DOMContentLoaded", () => {
+  ensureWrap();
+  resizeOverlayToVideo();
+  renderSessionStats();
+  // Make the click overlay transparent by default so the video controls
+  // are usable immediately in editor mode.
+  clickOverlay.style.pointerEvents = "none";
+});
 videoEl?.addEventListener("loadedmetadata", resizeOverlayToVideo);
 videoEl?.addEventListener("loadedmetadata", () => {
   if (scenario.version < 3) {

--- a/styles.css
+++ b/styles.css
@@ -53,7 +53,7 @@ button:disabled { background: #3b4150; cursor: not-allowed; }
   width: 100%;
   height: 100%;
   z-index: 2;
-  pointer-events: auto;
+  pointer-events: none;
 }
 #overlayPrompt, #optionsWrap { position: absolute; }
 #overlayPrompt { background: #2a6ef1; color: #FFFFFF; font-size: 120%; font-weight: bold; text-shadow: 0 0 3px #000; padding: 10px 14px; border-radius: 8px; pointer-events: none; max-width: 70%; text-align: center; }


### PR DESCRIPTION
## Summary
- Disable pointer events on the editor's click overlay by default
- Reset overlay to transparent after cleaning editor handlers
- Ensure overlay starts transparent on initial page load so video seeking and play/pause work

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ab71aa950c832197ff6c130d186a30