### PR TITLE
Disable video controls and centralize playback toggling

### DIFF
--- a/app.js
+++ b/app.js
@@ -83,7 +83,7 @@ function globalKeyHandler(e) {
     case KEYMAP.playPause:
       e.preventDefault();
       if (!videoEl.src || awaitingAnswer) break;
-      if (videoEl.paused) { videoEl.play(); } else { videoEl.pause(); }
+      togglePlayback();
       flashButton(playPauseBtn);
       break;
     case KEYMAP.predict:
@@ -397,6 +397,7 @@ function startSession() {
   playQueue = scenario.stops.map((_,i)=>i);
   nextStopIdx = 0; results = [];
   sessionActive = true; editorMode = false;
+  videoEl.controls = false;
   hidePrompt(); clearOptions(); sessionEnd?.classList.add("hidden");
   // Compte à rebours 5 -> 1 -> GO puis lecture
   runCountdownThen(() => {
@@ -530,7 +531,7 @@ function handleStop(index) {
       awaitingAnswer = false;
       nextStopIdx++; pauseGuard = false;
       if (nextStopIdx >= playQueue.length) { endSessionWithDelay(); }
-      else { videoEl.play(); requestAnimationFrame(tickStopWatcher); }
+      else { togglePlayback(); requestAnimationFrame(tickStopWatcher); }
     };
     clickOverlay.addEventListener("click", clickHandler);
 
@@ -568,7 +569,7 @@ function handleStop(index) {
       awaitingAnswer = false;
       nextStopIdx++; pauseGuard = false;
       if (nextStopIdx >= playQueue.length) { endSessionWithDelay(); }
-      else { videoEl.play(); requestAnimationFrame(tickStopWatcher); }
+      else { togglePlayback(); requestAnimationFrame(tickStopWatcher); }
     };
     clickOverlay.addEventListener("click", clickHandler, { once:true });
 
@@ -596,7 +597,7 @@ function handleStop(index) {
         awaitingAnswer = false;
         nextStopIdx++; pauseGuard = false;
         if (nextStopIdx >= playQueue.length) { endSessionWithDelay(); }
-        else { videoEl.play(); requestAnimationFrame(tickStopWatcher); }
+        else { togglePlayback(); requestAnimationFrame(tickStopWatcher); }
       }, endScreenDelayMs);
     });
     showPrompt("Choisis le <b>coup</b> que tu jouerais dans cette situation.");
@@ -1188,9 +1189,6 @@ function togglePlayback() {
   if (!canTogglePlayback()) return;
   if (videoEl.paused) { videoEl.play(); } else { videoEl.pause(); }
 }
-
-// Lecture/Pause bouton
-playPauseBtn?.addEventListener("click", togglePlayback);
 
 // Toggle play/pause when clicking/tapping on the video area
 videoContainer?.addEventListener("pointerup", (e) => {


### PR DESCRIPTION
## Summary
- Disable native video controls when a session starts
- Centralize playback control through `togglePlayback` and remove extraneous click toggles

## Testing
- `node --check app.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ab758b04048321b985933f2186edee