### PR TITLE
Use togglePlayback for keyboard shortcut and rely on shared state checks

### DIFF
--- a/app.js
+++ b/app.js
@@ -82,7 +82,6 @@ function globalKeyHandler(e) {
   switch (key) {
     case KEYMAP.playPause:
       e.preventDefault();
-      if (!videoEl.src || awaitingAnswer) break;
       togglePlayback();
       flashButton(playPauseBtn);
       break;


### PR DESCRIPTION
## Summary
- Simplify global key handler to call `togglePlayback()` for play/pause
- Remove redundant key handler checks now handled by `canTogglePlayback`
- Centralized toggle respects session locks like `awaitingAnswer` and `isCentering`

## Testing
- `npm test` *(fails: Could not read package.json)*
- `node /tmp/test-toggle-locks.js`


------
https://chatgpt.com/codex/tasks/task_e_68ab76b479c88321bb9fb38d7c02106f