### PR TITLE
Handle pointer overlay with native controls visible

### DIFF
--- a/app.js
+++ b/app.js
@@ -1199,6 +1199,7 @@ startSession();
 
 // Toggle play/pause when clicking/tapping on the video area
 videoContainer?.addEventListener("pointerup", (e) => {
+  if (videoEl.controls) return;
   if (e.button !== 0) return;
   if (e.target !== videoEl && e.target !== clickOverlay) return;
   togglePlayback();


### PR DESCRIPTION
## Summary
- Prevent overlay click handler from toggling playback when native video controls are enabled

## Testing
- `node --check app.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ab79fd87d483218c43d03700e2cf06