### PR TITLE
Fix zone selection overlay enabling for 2x2 mode

### DIFF
--- a/app.js
+++ b/app.js
@@ -1069,6 +1069,7 @@ function chooseZoneForStop(index) {
   // Ensure any previous zone handler is cleared before binding a new one.
   cleanupEditorClickHandlers();
   showPrompt("Clique maintenant dans la <b>zone correcte</b> (1/2/3/4).");
+  clickOverlay.style.pointerEvents = "auto";
   zoneSelectHandler = (evt) => {
     const rel = getClickCoords(evt);
     const z = getZoneFromSplit(rel.relX, rel.relY, stop.gridSplit);


### PR DESCRIPTION
## Summary
- Re-enable click handling on the overlay before selecting a zone so the third click records the chosen quadrant and resets editor state.

## Testing
- `node <<'NODE' ... NODE`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ace22ba7d883219f114c03a61db5e6